### PR TITLE
feature/#30 reformat and refactor remaining codes

### DIFF
--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/channel/service/ChannelService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/channel/service/ChannelService.kt
@@ -28,8 +28,9 @@ class ChannelService(
 
         val member = memberRepository.findByIdOrNull(memberId)
             ?: throw ModelNotFoundException("Member", memberId)
-        member.role = MemberRole.CHANNEL_ADMIN
+        member.assignChannelAdmin()
 
+        memberRepository.save(member)
         return channelRepository.save(
             Channel.from(
                 request = request,

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/AuthController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/AuthController.kt
@@ -20,11 +20,16 @@ class AuthController(
 
     @PostMapping("/signin")
     fun signin(@RequestBody request: SigninRequest): ResponseEntity<SigninResponse> =
-        ResponseEntity.status(HttpStatus.OK).body(authService.signin(request))
+
+        ResponseEntity
+            .status(HttpStatus.OK)
+            .body(authService.signin(request))
 
 
     @PostMapping("/signup")
     fun signup(@RequestBody request: SignupRequest): ResponseEntity<MemberResponse> =
-        ResponseEntity.status(HttpStatus.CREATED).body(authService.signup(request))
 
+        ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(authService.signup(request))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/MemberController.kt
@@ -21,10 +21,16 @@ class MemberController(
 
     @GetMapping("/member")
     fun getMember(@AuthenticationPrincipal principal: MemberPrincipal): ResponseEntity<MemberResponse> =
-        ResponseEntity.status(HttpStatus.OK).body(memberService.getMember(principal.id))
+
+        ResponseEntity
+            .status(HttpStatus.OK)
+            .body(memberService.getMember(principal.id))
+
 
     @GetMapping("/members/{id}")
     fun getSimpleMember(@PathVariable id: String): ResponseEntity<MemberSimplifiedResponse> =
-        ResponseEntity.status(HttpStatus.OK).body(memberService.getSimpleMember(UUID.fromString(id)))
 
+        ResponseEntity
+            .status(HttpStatus.OK)
+            .body(memberService.getSimpleMember(UUID.fromString(id)))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/request/SigninRequest.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/request/SigninRequest.kt
@@ -7,6 +7,7 @@ data class SigninRequest(
     @field: Email
     @field: NotBlank
     val email: String,
+
     @field: NotBlank
     val password: String
 )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/request/SignupRequest.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/request/SignupRequest.kt
@@ -5,11 +5,13 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 data class SignupRequest(
-    @field:Email
+    @field: Email
     @field: NotBlank
     val email: String,
-    @field:Size(min = 8, max = 64, message = "최소 8자에서 최대 64자까지 입력 가능합니다.")
+
+    @field: Size(min = 8, max = 64, message = "최소 8자에서 최대 64자까지 입력 가능합니다.")
     val password: String,
-    @field:Size(min = 2, max = 16, message = "최소 2자에서 최대 16자까지 입력 가능합니다.")
-    val nickname: String,
+
+    @field: Size(min = 2, max = 16, message = "최소 2자에서 최대 16자까지 입력 가능합니다.")
+    val nickname: String
 )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/response/MemberResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/response/MemberResponse.kt
@@ -1,18 +1,9 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response
 
-import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
 import java.util.UUID
 
 data class MemberResponse(
     val id: UUID,
     val email: String,
     val nickname: String
-) {
-
-    companion object {
-
-        fun from(member: Member): MemberResponse =
-
-            MemberResponse(member.id, member.email, member.nickname)
-    }
-}
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/response/MemberResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/response/MemberResponse.kt
@@ -10,8 +10,9 @@ data class MemberResponse(
 ) {
 
     companion object {
-        fun from(member: Member): MemberResponse {
-            return MemberResponse(member.id, member.email, member.nickname)
-        }
+
+        fun from(member: Member): MemberResponse =
+
+            MemberResponse(member.id, member.email, member.nickname)
     }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/response/MemberSimplifiedResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/response/MemberSimplifiedResponse.kt
@@ -9,7 +9,9 @@ class MemberSimplifiedResponse(
 ) {
 
     companion object {
+
         fun from(member: Member): MemberSimplifiedResponse =
+
             MemberSimplifiedResponse(member.id, member.nickname)
     }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/response/MemberSimplifiedResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/response/MemberSimplifiedResponse.kt
@@ -1,17 +1,8 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response
 
-import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
 import java.util.UUID
 
 class MemberSimplifiedResponse(
     val id: UUID,
     val nickname: String
-) {
-
-    companion object {
-
-        fun from(member: Member): MemberSimplifiedResponse =
-
-            MemberSimplifiedResponse(member.id, member.nickname)
-    }
-}
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/Member.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/Member.kt
@@ -41,14 +41,14 @@ class Member(
 ) {
 
     companion object {
-        fun from(email: String, password: String, nickname: String): Member {
-            return Member(
+
+        fun from(email: String, password: String, nickname: String): Member =
+
+            Member(
                 email = email,
                 password = password,
                 nickname = nickname,
                 createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
             )
-        }
     }
-
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/Member.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/Member.kt
@@ -1,44 +1,52 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model
 
 import jakarta.persistence.*
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.BaseTimeEntity
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberSimplifiedResponse
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.UUID
 
 @Entity
 @Table(name = "member")
-class Member(
+class Member private constructor(
+    email: String,
+    password: String,
+    nickname: String
+) : BaseTimeEntity() {
+
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: UUID = UUID.randomUUID()
 
     @Column(name = "email", nullable = false, unique = true)
-    val email: String,
+    val email: String = email
 
     @Column(name = "password", nullable = false)
-    var password: String,
+    var password: String = password
+        private set
 
     @Column(name = "nickname", nullable = false, unique = true)
-    var nickname: String,
+    var nickname: String = nickname
+        private set
 
     @Column(name = "lv", nullable = false)
-    var lv: Int = 0,
+    var lv: Int = 0
+        private set
 
     @Column(name = "exp_point", nullable = false)
-    var expPoint: Int = 0,
+    var expPoint: Int = 0
+        private set
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
-    var role: MemberRole = MemberRole.USER,
-
-    @Column(name = "created_at", nullable = false)
-    val createdAt: ZonedDateTime,
-
-    @Column(name = "updated_at")
-    var updatedAt: ZonedDateTime? = null,
+    var role: MemberRole = MemberRole.USER
+        private set
 
     @Column(name = "password_updated_at")
-    var passwordUpdatedAt: ZonedDateTime? = null,
-) {
+    var passwordUpdatedAt: ZonedDateTime? = null
+        private set
+
 
     companion object {
 
@@ -48,7 +56,28 @@ class Member(
                 email = email,
                 password = password,
                 nickname = nickname,
-                createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
             )
     }
+
+
+    fun assignChannelAdmin() {
+
+        role = MemberRole.CHANNEL_ADMIN
+    }
 }
+
+fun Member.toResponse(): MemberResponse =
+
+    MemberResponse(
+        id = id,
+        email = email,
+        nickname = nickname
+    )
+
+
+fun Member.toSimplifiedResponse(): MemberSimplifiedResponse =
+
+    MemberSimplifiedResponse(
+        id = id,
+        nickname = nickname
+    )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/repository/MemberRepository.kt
@@ -5,6 +5,7 @@ import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.do
 import java.util.UUID
 
 interface MemberRepository : JpaRepository<Member, UUID> {
+
     fun existsByEmail(email: String): Boolean
     fun findByEmail(email: String): Member?
     fun existsByNickname(nickname: String): Boolean

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/AuthService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/AuthService.kt
@@ -9,6 +9,7 @@ import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.do
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.request.SignupRequest
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.MemberRole
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.toResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MemberRepository
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.jwt.JwtHelper
 
@@ -22,16 +23,20 @@ class AuthService(
     @Transactional
     fun signup(request: SignupRequest): MemberResponse {
 
-        if (memberRepository.existsByEmail(request.email)) throw IllegalArgumentException("이미 가입된 이메일")
-        if (memberRepository.existsByNickname(request.nickname)) throw IllegalArgumentException("이미 존재하는 닉네임")
+        if (memberRepository.existsByEmail(request.email))
+            throw IllegalArgumentException("이미 가입된 이메일")
+        if (memberRepository.existsByNickname(request.nickname))
+            throw IllegalArgumentException("이미 존재하는 닉네임")
 
-        return Member.from(
-            email = request.email,
-            password = passwordEncoder.encode(request.password),
-            nickname = request.nickname,
-        ).let { memberRepository.save(it) }
-            .let { MemberResponse.from(it) }
+        return memberRepository.save(
+            Member.from(
+                email = request.email,
+                password = passwordEncoder.encode(request.password),
+                nickname = request.nickname,
+            )
+        ).toResponse()
     }
+
 
     fun signin(request: SigninRequest): SigninResponse {
 
@@ -41,7 +46,7 @@ class AuthService(
             throw IllegalArgumentException("password가 일치하지 않습니다.")
 
         return SigninResponse(
-            jwtHelper.generateAccessToken(
+            accessToken = jwtHelper.generateAccessToken(
                 subject = member.id.toString(),
                 email = member.email,
                 role = MemberRole.USER.name

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/AuthService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/AuthService.kt
@@ -21,8 +21,10 @@ class AuthService(
 
     @Transactional
     fun signup(request: SignupRequest): MemberResponse {
+
         if (memberRepository.existsByEmail(request.email)) throw IllegalArgumentException("이미 가입된 이메일")
         if (memberRepository.existsByNickname(request.nickname)) throw IllegalArgumentException("이미 존재하는 닉네임")
+
         return Member.from(
             email = request.email,
             password = passwordEncoder.encode(request.password),
@@ -32,12 +34,12 @@ class AuthService(
     }
 
     fun signin(request: SigninRequest): SigninResponse {
-        val member = memberRepository.findByEmail(request.email) ?: throw IllegalArgumentException("회원정보를 찾을 수 없습니다.")
-        if (!passwordEncoder.matches(
-                request.password,
-                member.password
-            )
-        ) throw IllegalArgumentException("password가 일치하지 않습니다.")
+
+        val member = memberRepository.findByEmail(request.email)
+            ?: throw IllegalArgumentException("회원정보를 찾을 수 없습니다.")
+        if (!passwordEncoder.matches(request.password, member.password))
+            throw IllegalArgumentException("password가 일치하지 않습니다.")
+
         return SigninResponse(
             jwtHelper.generateAccessToken(
                 subject = member.id.toString(),
@@ -46,5 +48,4 @@ class AuthService(
             )
         )
     }
-
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/MemberService.kt
@@ -6,23 +6,26 @@ import org.springframework.stereotype.Service
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberSimplifiedResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.toResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.toSimplifiedResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MemberRepository
 import java.util.UUID
 
 @Service
 class MemberService(
-    private val repository: MemberRepository
+    private val memberRepository: MemberRepository
 ) {
 
-    fun getMember(id: UUID): MemberResponse {
+    fun getMember(id: UUID): MemberResponse =
 
-        val member = repository.findByIdOrNull(id) ?: throw EntityNotFoundException("model not found")
-        return MemberResponse.from(member)
-    }
+        memberRepository.findByIdOrNull(id)
+            ?.toResponse()
+            ?: throw EntityNotFoundException("model not found")
 
-    fun getSimpleMember(id: UUID): MemberSimplifiedResponse {
-        
-        val member = repository.findByIdOrNull(id) ?: throw EntityNotFoundException("model not found")
-        return MemberSimplifiedResponse.from(member)
-    }
+
+    fun getSimpleMember(id: UUID): MemberSimplifiedResponse =
+
+        memberRepository.findByIdOrNull(id)
+            ?.toSimplifiedResponse()
+            ?: throw EntityNotFoundException("model not found")
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/MemberService.kt
@@ -15,11 +15,13 @@ class MemberService(
 ) {
 
     fun getMember(id: UUID): MemberResponse {
+
         val member = repository.findByIdOrNull(id) ?: throw EntityNotFoundException("model not found")
         return MemberResponse.from(member)
     }
 
     fun getSimpleMember(id: UUID): MemberSimplifiedResponse {
+        
         val member = repository.findByIdOrNull(id) ?: throw EntityNotFoundException("model not found")
         return MemberSimplifiedResponse.from(member)
     }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/exception/GlobalExceptionHandler.kt
@@ -12,21 +12,28 @@ import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.ex
 class GlobalExceptionHandler {
 
     @ExceptionHandler(ModelNotFoundException::class)
-    fun handleModelNotFoundException(e: ModelNotFoundException): ResponseEntity<ErrorResponse> {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse(e.message))
-    }
+    fun handleModelNotFoundException(e: ModelNotFoundException): ResponseEntity<ErrorResponse> =
+
+        ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(e.message))
+
 
     @ExceptionHandler(CustomAccessDeniedException::class)
-    fun handleCustomAccessDeniedException(e: CustomAccessDeniedException): ResponseEntity<ErrorResponse> {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse(e.message))
-    }
+    fun handleCustomAccessDeniedException(e: CustomAccessDeniedException): ResponseEntity<ErrorResponse> =
+
+        ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
+            .body(ErrorResponse(e.message))
+
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleMethodArgumentNotValidException(
         e: MethodArgumentNotValidException,
         bindingResult: BindingResult
-    ): ResponseEntity<ErrorResponse> {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+    ): ResponseEntity<ErrorResponse> =
+
+        ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse(bindingResult.fieldError?.defaultMessage))
-    }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/exception/ModelNotFoundException.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/exception/ModelNotFoundException.kt
@@ -1,5 +1,6 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.exception
 
-data class ModelNotFoundException(val modelName: String, val id: Any) : RuntimeException(
-    "Model $modelName not found with given id: $id"
-)
+data class ModelNotFoundException(
+    val modelName: String,
+    val id: Any
+) : RuntimeException("Model $modelName not found with given id: $id")

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/Cookie.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/Cookie.kt
@@ -31,6 +31,7 @@ class CookieUtil {
             return response.addCookie(viewCountCookie)
         }
 
+
         private fun getRemainingTimeUntilMidnight(): Int {
 
             val now = LocalDateTime.now()

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/CustomAuthenticationEntryPoint.kt
@@ -16,6 +16,7 @@ class CustomAuthenticationEntryPoint : AuthenticationEntryPoint {
         response: HttpServletResponse,
         authException: AuthenticationException,
     ) {
+
         response.status = HttpServletResponse.SC_UNAUTHORIZED
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.characterEncoding = "UTF-8"

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/config/PasswordEncoderConfig.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/config/PasswordEncoderConfig.kt
@@ -9,7 +9,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 class PasswordEncoderConfig {
 
     @Bean
-    fun passwordEncoder(): PasswordEncoder {
-        return BCryptPasswordEncoder()
-    }
+    fun passwordEncoder(): PasswordEncoder =
+
+        BCryptPasswordEncoder()
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/config/SecurityConfig.kt
@@ -20,8 +20,9 @@ class SecurityConfig(
 ) {
 
     @Bean
-    fun filterChain(http: HttpSecurity): SecurityFilterChain {
-        return http
+    fun filterChain(http: HttpSecurity): SecurityFilterChain =
+
+        http
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
             .csrf { it.disable() }
@@ -40,5 +41,4 @@ class SecurityConfig(
                 it.authenticationEntryPoint(authenticationEntryPoint)
             }
             .build()
-    }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/jwt/JwtHelper.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/jwt/JwtHelper.kt
@@ -19,9 +19,15 @@ class JwtHelper(
 ) {
 
     fun validateToken(jwt: String): Result<Jws<Claims>> =
+
         kotlin.runCatching {
             Keys.hmacShaKeyFor(accessTokenSecret.toByteArray())
-                .let { Jwts.parser().verifyWith(it).build().parseSignedClaims(jwt) }
+                .let {
+                    Jwts.parser()
+                        .verifyWith(it)
+                        .build()
+                        .parseSignedClaims(jwt)
+                }
         }
 
 
@@ -30,6 +36,7 @@ class JwtHelper(
         email: String,
         role: String
     ): String =
+
         generateToken(subject, email, role, Duration.ofHours(accessTokenExpirationHour.toLong()))
 
 
@@ -38,18 +45,20 @@ class JwtHelper(
         email: String,
         role: String,
         expirationPeriod: Duration
-    ): String {
-        val claims = Jwts.claims().add(mapOf("email" to email, "role" to role)).build()
-        val now = Instant.now()
-        val key = Keys.hmacShaKeyFor(accessTokenSecret.toByteArray())
+    ): String =
 
-        return Jwts.builder()
-            .subject(subject)
-            .issuer(issuer)
-            .issuedAt(Date.from(now))
-            .expiration(Date.from(now.plus(expirationPeriod)))
-            .claims(claims)
-            .signWith(key)
-            .compact()
-    }
+        Instant.now().let { now ->
+            Jwts.builder()
+                .subject(subject)
+                .issuer(issuer)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(expirationPeriod)))
+                .claims(
+                    Jwts.claims()
+                        .add( mapOf("email" to email, "role" to role) )
+                        .build()
+                )
+                .signWith(Keys.hmacShaKeyFor(accessTokenSecret.toByteArray()))
+                .compact()
+        }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/jwt/jwtAuthenticationFilter.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/jwt/jwtAuthenticationFilter.kt
@@ -19,6 +19,7 @@ class jwtAuthenticationFilter(
         private val BEARER_PATTERN = Regex("^Bearer (.+?)$")
     }
 
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -42,14 +43,16 @@ class jwtAuthenticationFilter(
                         SecurityContextHolder.getContext().authentication = authentication
                     }
                 }
-
         }
         filterChain.doFilter(request, response)
     }
 
-    private fun HttpServletRequest.getBearer(): String? {
-        return this.getHeader(HttpHeaders.AUTHORIZATION)?.let {
-            BEARER_PATTERN.find(it)?.groupValues?.get(1)
+
+    private fun HttpServletRequest.getBearer(): String? =
+
+        this.getHeader(HttpHeaders.AUTHORIZATION)?.let {
+            BEARER_PATTERN.find(it)
+                ?.groupValues
+                ?.get(1)
         }
-    }
 }


### PR DESCRIPTION
# 개요

`Member` 도메인과 (도메인을 제외한 나머지) 패키지들의 리포맷팅/리팩터링 진행

# 작업사항

- [x] Member 도메인 쪽 코드 리포맷팅 진행
- [x] infra 등 남아있는 패키지 쪽 코드 리포맷팅 진행
- [x] (필요할 경우) 리팩토링 진행
    - [x] `Member`의 `Response` `DTO` 생성 함수를 `DTO`에서 `Entity` 쪽으로 이동
    - [x] `Member` `Entity`의 생성자 변경(직접적인 생성자 대신 `from`을 사용하게 변경)

# 관련 이슈

- close #30