### PR TITLE
Feature/#33 reinforce basic crud

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     kotlin("plugin.jpa") version "1.9.24"
     kotlin("jvm") version "1.9.24"
     kotlin("plugin.spring") version "1.9.24"
+    kotlin("kapt") version "1.9.24"
 }
 
 group = "spartacodingclub.nbcamp.kotlinspring.project.team4ighting"
@@ -19,6 +20,8 @@ repositories {
     mavenCentral()
 }
 
+val queryDslVersion = "5.0.0"
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
@@ -27,18 +30,20 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-
-
     implementation("io.jsonwebtoken:jjwt-api:0.12.5")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+    implementation("com.querydsl:querydsl-jpa:$queryDslVersion:jakarta")
+    kapt("com.querydsl:querydsl-apt:$queryDslVersion:jakarta")
+
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
-
-    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
-
     runtimeOnly("com.mysql:mysql-connector-j")
+
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
+
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/controller/CommentController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.dto.response.CommentResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.dto.request.CreateCommentRequest
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.dto.request.UpdateCommentRequest
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.dto.response.CommentReportResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.service.CommentService
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.MemberPrincipal
 
@@ -111,4 +112,19 @@ class CommentController(
         ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .body(commentService.deleteReaction(channelId, boardId, postId, commentId, member.id))
+
+
+    @PostMapping("/{commentId}/report")
+    fun reportComment(
+        @AuthenticationPrincipal member: MemberPrincipal,
+        @PathVariable channelId: Long,
+        @PathVariable boardId: Long,
+        @PathVariable postId: Long,
+        @PathVariable commentId: Long,
+        @RequestBody reason: String
+    ): ResponseEntity<CommentReportResponse> =
+
+        ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(commentService.reportComment(channelId, boardId, postId, commentId, member.id, reason))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/controller/CommentController.kt
@@ -78,4 +78,37 @@ class CommentController(
         ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .body(commentService.deleteComment(channelId, boardId, postId, commentId, member.id))
+
+
+    /*
+     * 반응 관련
+     */
+
+    @PutMapping("/{commentId}/reaction")
+    fun addReaction(
+        @AuthenticationPrincipal member: MemberPrincipal,
+        @PathVariable channelId: Long,
+        @PathVariable boardId: Long,
+        @PathVariable postId: Long,
+        @PathVariable commentId: Long,
+        @RequestParam("is-upvoting") isUpvoting: Boolean
+    ): ResponseEntity<Unit> =
+
+        ResponseEntity
+            .status(HttpStatus.OK)
+            .body(commentService.addReaction(channelId, boardId, postId, commentId, member.id, isUpvoting))
+
+
+    @DeleteMapping("/{commentId}/reaction")
+    fun deleteReaction(
+        @AuthenticationPrincipal member: MemberPrincipal,
+        @PathVariable channelId: Long,
+        @PathVariable boardId: Long,
+        @PathVariable postId: Long,
+        @PathVariable commentId: Long
+    ): ResponseEntity<Unit> =
+
+        ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .body(commentService.deleteReaction(channelId, boardId, postId, commentId, member.id))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/dto/response/CommentReportResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/dto/response/CommentReportResponse.kt
@@ -1,0 +1,12 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.dto.response
+
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.ReportStatus
+import java.util.UUID
+
+data class CommentReportResponse(
+    val id: Long,
+    val commentInfo: CommentResponse,
+    val reason: String,
+    val subject: UUID,
+    val status: ReportStatus
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/dto/response/CommentResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/dto/response/CommentResponse.kt
@@ -6,8 +6,8 @@ data class CommentResponse(
     val id: Long,
     val content: String,
     val author: String,
-//    val upvoteCount: Int,
-//    val downvoteCount: Int
+    val upvotes: Long,
+    val downvotes: Long,
     val createdAt: ZonedDateTime,
     val updatedAt: ZonedDateTime
 )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/Comment.kt
@@ -63,6 +63,8 @@ fun Comment.toResponse(): CommentResponse =
         id = id!!,
         content = content,
         author = author,
+        upvotes = upvotes,
+        downvotes = downvotes,
         createdAt = createdAt,
         updatedAt = updatedAt
     )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/Comment.kt
@@ -1,8 +1,8 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.model
 
 import jakarta.persistence.*
-import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.BaseTimeEntity
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.dto.response.CommentResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.ReactableEntity
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model.Post
 import java.util.*
 
@@ -13,7 +13,7 @@ class Comment private constructor(
     memberId: UUID,
     post: Post,
     author: String
-) : BaseTimeEntity() {
+) : ReactableEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/CommentReaction.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/CommentReaction.kt
@@ -1,0 +1,37 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+
+@Entity
+@Table(name = "comment_reaction")
+class CommentReaction private constructor (
+    member: Member,
+    comment: Comment,
+    isUpvoting: Boolean
+) {
+
+    @EmbeddedId
+    val id: CommentReactionid = CommentReactionid(
+        member = member,
+        comment = comment
+    )
+
+    @Column(name = "is_upvoting")
+    var isUpvoting: Boolean = isUpvoting
+
+
+    companion object {
+
+        fun from(member: Member, comment: Comment, isUpvoting: Boolean): CommentReaction =
+
+            CommentReaction(
+                member = member,
+                comment = comment,
+                isUpvoting = isUpvoting
+            )
+    }
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/CommentReactionid.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/CommentReactionid.kt
@@ -1,0 +1,18 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.model
+
+import jakarta.persistence.Embeddable
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+
+@Embeddable
+class CommentReactionid (
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    var comment: Comment? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    var member: Member? = null
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/CommentReport.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/CommentReport.kt
@@ -1,0 +1,55 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.model
+
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.dto.response.CommentReportResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.BaseReport
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+
+@Entity
+@Table(name = "comment_report")
+class CommentReport private constructor(
+    comment: Comment,
+    reason: String,
+    subject: Member
+) : BaseReport(
+    reason = reason,
+    subject = subject
+) {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    val comment: Comment = comment
+
+
+    companion object {
+
+        fun from(comment: Comment, reason: String, subject: Member): CommentReport =
+
+            CommentReport(
+                comment = comment,
+                reason = reason,
+                subject = subject
+            )
+    }
+}
+
+
+fun CommentReport.toResponse(): CommentReportResponse =
+
+    CommentReportResponse(
+        id = id!!,
+        commentInfo = comment.toResponse(),
+        reason = reason,
+        subject = subject!!.id,
+        status = status
+    )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/repository/CommentReactionRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/repository/CommentReactionRepository.kt
@@ -1,0 +1,11 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.model.CommentReaction
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.model.CommentReactionid
+import java.util.UUID
+
+interface CommentReactionRepository : JpaRepository<CommentReaction, CommentReactionid> {
+
+    fun findByIdCommentIdAndIdMemberId(commentId: Long, memberId: UUID): CommentReaction?
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/repository/CommentReportRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/repository/CommentReportRepository.kt
@@ -1,0 +1,6 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.model.CommentReport
+
+interface CommentReportRepository : JpaRepository<CommentReport, Long>

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/common/type/BaseReport.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/common/type/BaseReport.kt
@@ -1,0 +1,20 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type
+
+import jakarta.persistence.*
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+
+@MappedSuperclass
+open class BaseReport (
+
+    @Column(name = "reason", nullable = false)
+    var reason: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    var subject: Member? = null
+) : BaseTimeEntity() {
+
+    @Enumerated(EnumType.ORDINAL)
+    @Column(name = "status", nullable = false)
+    var status: ReportStatus = ReportStatus.SUBMITTED
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/common/type/ReactableEntity.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/common/type/ReactableEntity.kt
@@ -1,0 +1,58 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type
+
+import jakarta.persistence.Column
+import jakarta.persistence.MappedSuperclass
+
+@MappedSuperclass
+open class ReactableEntity : BaseTimeEntity() {
+
+    @Column(name = "upvotes", nullable = false)
+    var upvotes: Long = 0
+
+    @Column(name = "downvotes", nullable = false)
+    var downvotes: Long = 0
+
+
+    fun increaseReaction(isReactionUpvoting: Boolean) {
+
+        if (isReactionUpvoting)
+            this.increaseUpvote()
+        else
+            this.increaseDownvote()
+    }
+
+    fun decreaseReaction(isReactionUpvoting: Boolean) {
+
+        if (isReactionUpvoting)
+            this.decreaseUpvote()
+        else
+            this.decreaseDownvote()
+    }
+
+    fun applySwitchedReaction(isNewReactionUpvoting: Boolean) {
+
+        this.decreaseReaction(!isNewReactionUpvoting)
+        this.increaseReaction(isNewReactionUpvoting)
+    }
+
+
+    private fun increaseUpvote() {
+
+        this.upvotes += 1
+    }
+
+    private fun increaseDownvote() {
+
+        this.downvotes += 1
+    }
+
+    private fun decreaseUpvote() {
+
+        this.upvotes -= 1
+    }
+
+    private fun decreaseDownvote() {
+
+        this.downvotes -= 1
+    }
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/common/type/ReportStatus.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/common/type/ReportStatus.kt
@@ -1,0 +1,7 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type
+
+enum class ReportStatus {
+    SUBMITTED,
+    IN_PROGRESS,
+    COMPLETE
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/controller/GameReviewController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/controller/GameReviewController.kt
@@ -1,6 +1,7 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.controller
 
 import jakarta.validation.Valid
+import org.apache.coyote.Response
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
@@ -76,6 +77,33 @@ class GameReviewController(
         ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .body(gameReviewService.deleteGameReview(gameReviewId, member.id))
+
+
+    /*
+     * 반응 관련
+     */
+
+    @PutMapping("/{gameReviewId}/reactions")
+    fun addReaction(
+        @AuthenticationPrincipal member: MemberPrincipal,
+        @PathVariable gameReviewId: Long,
+        @RequestParam("is-upvoting") isUpvoting: Boolean
+    ): ResponseEntity<Unit> =
+
+        ResponseEntity
+            .status(HttpStatus.OK)
+            .body(gameReviewService.addReaction(gameReviewId, member.id, isUpvoting))
+
+
+    @DeleteMapping("/{gameReviewId}/reactions")
+    fun deleteReaction(
+        @AuthenticationPrincipal member: MemberPrincipal,
+        @PathVariable gameReviewId: Long
+    ): ResponseEntity<Unit> =
+
+        ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .body(gameReviewService.deleteReaction(gameReviewId, member.id))
 
 
     // TODO: 리뷰 신고 - POST

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/controller/GameReviewController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/controller/GameReviewController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.CreateGameReviewRequest
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.UpdateGameReviewRequest
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReportResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.service.GameReviewService
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.MemberPrincipal
 
@@ -83,7 +84,7 @@ class GameReviewController(
      * 반응 관련
      */
 
-    @PutMapping("/{gameReviewId}/reactions")
+    @PutMapping("/{gameReviewId}/reaction")
     fun addReaction(
         @AuthenticationPrincipal member: MemberPrincipal,
         @PathVariable gameReviewId: Long,
@@ -95,7 +96,7 @@ class GameReviewController(
             .body(gameReviewService.addReaction(gameReviewId, member.id, isUpvoting))
 
 
-    @DeleteMapping("/{gameReviewId}/reactions")
+    @DeleteMapping("/{gameReviewId}/reaction")
     fun deleteReaction(
         @AuthenticationPrincipal member: MemberPrincipal,
         @PathVariable gameReviewId: Long
@@ -106,5 +107,14 @@ class GameReviewController(
             .body(gameReviewService.deleteReaction(gameReviewId, member.id))
 
 
-    // TODO: 리뷰 신고 - POST
+    @PostMapping("/{gameReviewId}/report")
+    fun reportGameReview(
+        @AuthenticationPrincipal member: MemberPrincipal,
+        @PathVariable gameReviewId: Long,
+        @RequestBody reason: String
+    ): ResponseEntity<GameReviewReportResponse> =
+
+        ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(gameReviewService.reportGameReview(gameReviewId, member.id, reason))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/dto/response/GameReviewReportResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/dto/response/GameReviewReportResponse.kt
@@ -1,0 +1,12 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response
+
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.ReportStatus
+import java.util.UUID
+
+data class GameReviewReportResponse(
+    val id: Long,
+    val gameReviewInfo: GameReviewResponse,
+    val reason: String,
+    val subject: UUID,
+    val status: ReportStatus
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/dto/response/GameReviewResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/dto/response/GameReviewResponse.kt
@@ -7,6 +7,8 @@ data class GameReviewResponse(
     val gameTitle: String,
     val point: Byte,
     val description: String,
+    val upvotes: Long,
+    val downvotes: Long,
     val createdAt: ZonedDateTime,
     val updatedAt: ZonedDateTime
 )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReview.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReview.kt
@@ -67,6 +67,8 @@ fun GameReview.toResponse(): GameReviewResponse =
         gameTitle = gameTitle,
         point = point,
         description = description,
+        upvotes = upvotes,
+        downvotes = downvotes,
         createdAt = createdAt,
         updatedAt = updatedAt
     )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReview.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReview.kt
@@ -1,7 +1,7 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model
 
 import jakarta.persistence.*
-import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.BaseTimeEntity
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.ReactableEntity
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.CreateGameReviewRequest
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewResponse
 import java.util.*
@@ -13,7 +13,7 @@ class GameReview private constructor(
     point: Byte,
     description: String,
     memberId: UUID
-) : BaseTimeEntity() {
+) : ReactableEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReviewReaction.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReviewReaction.kt
@@ -1,0 +1,37 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+
+@Entity
+@Table(name = "game_review_reaction")
+class GameReviewReaction private constructor (
+    member: Member,
+    gameReview: GameReview,
+    isUpvoting: Boolean
+) {
+
+    @EmbeddedId
+    val id: GameReviewReactionId = GameReviewReactionId(
+        member = member,
+        gameReview = gameReview
+    )
+
+    @Column(name = "is_upvoting")
+    var isUpvoting: Boolean = isUpvoting
+
+
+    companion object {
+
+        fun from(member: Member, gameReview: GameReview, isUpvoting: Boolean): GameReviewReaction =
+
+            GameReviewReaction(
+                member = member,
+                gameReview = gameReview,
+                isUpvoting = isUpvoting
+            )
+    }
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReviewReactionId.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReviewReactionId.kt
@@ -1,0 +1,18 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model
+
+import jakarta.persistence.Embeddable
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+
+@Embeddable
+class GameReviewReactionId (
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_review_id", nullable = false)
+    var gameReview: GameReview? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    var member: Member? = null
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReviewReport.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReviewReport.kt
@@ -1,0 +1,48 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model
+
+import jakarta.persistence.*
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.BaseReport
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReportResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+
+@Entity
+@Table(name = "game_review_report")
+class GameReviewReport private constructor (
+    gameReview: GameReview,
+    reason: String,
+    subject: Member
+) : BaseReport(
+    reason = reason,
+    subject = subject
+) {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_review_id", nullable = false)
+    val gameReview: GameReview = gameReview
+
+
+    companion object {
+
+        fun from(gameReview: GameReview, reason: String, subject: Member): GameReviewReport =
+
+            GameReviewReport(
+                gameReview = gameReview,
+                reason = reason,
+                subject = subject
+            )
+    }
+}
+
+
+fun GameReviewReport.toResponse(): GameReviewReportResponse =
+
+    GameReviewReportResponse(
+        id = id!!,
+        gameReviewInfo = gameReview.toResponse(),
+        reason = reason,
+        subject = subject!!.id,
+        status = status
+    )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/repository/GameReviewReactionRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/repository/GameReviewReactionRepository.kt
@@ -1,0 +1,11 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReviewReaction
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReviewReactionId
+import java.util.UUID
+
+interface GameReviewReactionRepository : JpaRepository<GameReviewReaction, GameReviewReactionId> {
+
+    fun findByIdGameReviewIdAndIdMemberId(gameReviewId: Long, memberId: UUID): GameReviewReaction?
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/repository/GameReviewReportRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/repository/GameReviewReportRepository.kt
@@ -1,0 +1,6 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReviewReport
+
+interface GameReviewReportRepository : JpaRepository<GameReviewReport, Long>

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
@@ -8,10 +8,13 @@ import org.springframework.transaction.annotation.Transactional
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.CreateGameReviewRequest
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.UpdateGameReviewRequest
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReportResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReview
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReviewReaction
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReviewReport
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.toResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.repository.GameReviewReactionRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.repository.GameReviewReportRepository
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.repository.GameReviewRepository
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MemberRepository
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.exception.CustomAccessDeniedException
@@ -22,7 +25,8 @@ import java.util.UUID
 class GameReviewService(
     private val gameReviewRepository: GameReviewRepository,
     private val memberRepository: MemberRepository,
-    private val gameReviewReactionRepository: GameReviewReactionRepository
+    private val gameReviewReactionRepository: GameReviewReactionRepository,
+    private val gameReviewReportRepository: GameReviewReportRepository
 ) {
 
     @Transactional
@@ -131,5 +135,26 @@ class GameReviewService(
 
         targetGameReview.decreaseReaction(reaction.isUpvoting)
         gameReviewReactionRepository.delete(reaction)
+    }
+
+
+    fun reportGameReview(
+        gameReviewId: Long,
+        memberId: UUID,
+        reason: String
+    ): GameReviewReportResponse {
+
+        val targetGameReview = gameReviewRepository.findByIdOrNull(gameReviewId)
+            ?: throw ModelNotFoundException("GameReview", gameReviewId)
+        val member = memberRepository.findByIdOrNull(memberId)
+            ?: throw ModelNotFoundException("Member", memberId)
+
+        return gameReviewReportRepository.save(
+            GameReviewReport.from(
+                gameReview = targetGameReview,
+                reason = reason,
+                subject = member
+            )
+        ).toResponse()
     }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/MemberController.kt
@@ -7,11 +7,13 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberSimplifiedResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MessageResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.service.MemberService
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.MemberPrincipal
 import java.util.UUID
@@ -37,6 +39,27 @@ class MemberController(
             .status(HttpStatus.OK)
             .body(memberService.getSimpleMember(UUID.fromString(id)))
 
+
+
+    /*
+     * 쪽지 관련
+     */
+
+    @PostMapping("/member/message")
+    fun addMessage(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @RequestParam("target-id") targetId: UUID,
+        @RequestBody message: String
+    ): ResponseEntity<MessageResponse> =
+
+        ResponseEntity
+            .status(HttpStatus.OK)
+            .body(memberService.addMessage(principal.id, targetId, message))
+
+
+    /*
+     * 차단 관련
+     */
 
     @PostMapping("/member/blacklist")
     fun addBlacklist(

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/MemberController.kt
@@ -3,9 +3,12 @@ package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.d
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberSimplifiedResponse
@@ -33,4 +36,26 @@ class MemberController(
         ResponseEntity
             .status(HttpStatus.OK)
             .body(memberService.getSimpleMember(UUID.fromString(id)))
+
+
+    @PostMapping("/member/blacklist")
+    fun addBlacklist(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @RequestParam("target-id") targetId: UUID
+    ): ResponseEntity<Unit> =
+
+        ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(memberService.addBlacklist(principal.id, targetId))
+
+
+    @DeleteMapping("/member/blacklist")
+    fun removeBlacklist(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @RequestParam("target-id") targetId: UUID
+    ): ResponseEntity<Unit> =
+
+        ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .body(memberService.removeBlacklist(principal.id, targetId))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/response/MessageResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/dto/response/MessageResponse.kt
@@ -1,0 +1,9 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response
+
+import java.util.*
+
+data class MessageResponse(
+    val subjectId: UUID,
+    val targetId: UUID,
+    val message: String
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/MemberBlacklist.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/MemberBlacklist.kt
@@ -1,0 +1,30 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model
+
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "member_blacklist")
+class MemberBlacklist private constructor (
+    subject: Member,
+    target: Member
+) {
+
+    @EmbeddedId
+    val id: MemberBlacklistId = MemberBlacklistId(
+        subject = subject,
+        target = target
+    )
+
+
+    companion object {
+
+        fun from(subject: Member, target: Member): MemberBlacklist =
+
+            MemberBlacklist(
+                subject = subject,
+                target = target
+            )
+    }
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/MemberBlacklistId.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/MemberBlacklistId.kt
@@ -1,0 +1,17 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model
+
+import jakarta.persistence.Embeddable
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Embeddable
+class MemberBlacklistId(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subject_id", nullable = false)
+    val subject: Member? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id", nullable = false)
+    val target: Member? = null
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/Message.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/Message.kt
@@ -1,0 +1,53 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model
+
+import jakarta.persistence.*
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.BaseTimeEntity
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MessageResponse
+
+@Entity
+@Table(name = "message")
+class Message private constructor(
+    subject: Member,
+    target: Member,
+    message: String
+) : BaseTimeEntity() {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subject_id", nullable = false)
+    val subject: Member? = subject
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id", nullable = false)
+    val target: Member? = target
+
+    @Column(name = "message")
+    val message: String = message
+
+
+    companion object {
+
+        fun from(
+            subject: Member,
+            target: Member,
+            message: String
+        ): Message =
+
+            Message(
+                subject = subject,
+                target = target,
+                message = message
+            )
+    }
+}
+
+
+fun Message.toResponse(): MessageResponse =
+
+    MessageResponse(
+        subjectId = subject!!.id,
+        targetId = target!!.id,
+        message = message
+    )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/repository/MemberBlacklistRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/repository/MemberBlacklistRepository.kt
@@ -1,0 +1,12 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.MemberBlacklist
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.MemberBlacklistId
+import java.util.UUID
+
+interface MemberBlacklistRepository : JpaRepository<MemberBlacklist, MemberBlacklistId> {
+
+    fun existsByIdSubjectIdAndIdTargetId(subjectId: UUID, targetId: UUID): Boolean
+    fun findByIdSubjectIdAndIdTargetId(subjectId: UUID, targetId: UUID): MemberBlacklist?
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/repository/MessageRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/repository/MessageRepository.kt
@@ -1,0 +1,11 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Message
+import java.util.UUID
+
+interface MessageRepository : JpaRepository<Message, Long> {
+
+    fun findAllBySubjectId(subjectId: UUID): List<Message>
+    fun findAllBySubjectIdAndTargetId(subjectId: UUID, targetId: UUID): List<Message>
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/MemberService.kt
@@ -5,15 +5,18 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberSimplifiedResponse
-import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.MemberBlacklist
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.toResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.toSimplifiedResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MemberBlacklistRepository
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MemberRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.exception.ModelNotFoundException
 import java.util.UUID
 
 @Service
 class MemberService(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val memberBlacklistRepository: MemberBlacklistRepository
 ) {
 
     fun getMember(id: UUID): MemberResponse =
@@ -28,4 +31,38 @@ class MemberService(
         memberRepository.findByIdOrNull(id)
             ?.toSimplifiedResponse()
             ?: throw EntityNotFoundException("model not found")
+
+
+    fun addBlacklist(
+        memberId: UUID,
+        targetId: UUID
+    ) {
+
+        val member = memberRepository.findByIdOrNull(memberId)
+            ?: throw ModelNotFoundException("Member", memberId)
+        val target = memberRepository.findByIdOrNull(targetId)
+            ?: throw ModelNotFoundException("Member", targetId)
+
+        if (memberBlacklistRepository.existsByIdSubjectIdAndIdTargetId(memberId, targetId))
+            throw IllegalArgumentException("Blacklist already added")
+
+        memberBlacklistRepository.save(
+            MemberBlacklist.from(
+                subject = member,
+                target = target
+            )
+        )
+    }
+
+
+    fun removeBlacklist(
+        memberId: UUID,
+        targetId: UUID
+    ) {
+
+        val targetMemberBlacklist = memberBlacklistRepository.findByIdSubjectIdAndIdTargetId(memberId, targetId)
+            ?: throw ModelNotFoundException("MemberBlacklist", "${memberId}/${targetId}")
+
+        memberBlacklistRepository.delete(targetMemberBlacklist)
+    }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/MemberService.kt
@@ -5,18 +5,22 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberSimplifiedResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MessageResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.MemberBlacklist
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Message
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.toResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.toSimplifiedResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MemberBlacklistRepository
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MemberRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MessageRepository
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.exception.ModelNotFoundException
 import java.util.UUID
 
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
-    private val memberBlacklistRepository: MemberBlacklistRepository
+    private val memberBlacklistRepository: MemberBlacklistRepository,
+    private val messageRepository: MessageRepository
 ) {
 
     fun getMember(id: UUID): MemberResponse =
@@ -31,6 +35,27 @@ class MemberService(
         memberRepository.findByIdOrNull(id)
             ?.toSimplifiedResponse()
             ?: throw EntityNotFoundException("model not found")
+
+
+    fun addMessage(
+        memberId: UUID,
+        targetId: UUID,
+        message: String
+    ): MessageResponse {
+
+        val member = memberRepository.findByIdOrNull(memberId)
+            ?: throw ModelNotFoundException("Member", memberId)
+        val target = memberRepository.findByIdOrNull(targetId)
+            ?: throw ModelNotFoundException("Member", targetId)
+
+        return messageRepository.save(
+            Message.from (
+                subject = member,
+                target = target,
+                message = message
+            )
+        ).toResponse()
+    }
 
 
     fun addBlacklist(

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/controller/PostController.kt
@@ -91,4 +91,35 @@ class PostController(
         ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .body(postService.deletePost(channelId, boardId, postId, member.id))
+
+
+    /*
+     * 반응 관련
+     */
+
+    @PutMapping("/{postId}/reaction")
+    fun addReaction(
+        @AuthenticationPrincipal member: MemberPrincipal,
+        @PathVariable channelId: Long,
+        @PathVariable boardId: Long,
+        @PathVariable postId: Long,
+        @RequestParam(name = "is-upvoting", required = true) isUpvoting: Boolean
+    ): ResponseEntity<Unit> =
+
+        ResponseEntity
+            .status(HttpStatus.OK)
+            .body(postService.addReaction(channelId, boardId, postId, member.id, isUpvoting))
+
+
+    @DeleteMapping("/{postId}/reaction")
+    fun deleteREaction(
+        @AuthenticationPrincipal member: MemberPrincipal,
+        @PathVariable channelId: Long,
+        @PathVariable boardId: Long,
+        @PathVariable postId: Long
+    ): ResponseEntity<Unit> =
+
+        ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .body(postService.deleteReaction(channelId, boardId, postId, member.id))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/controller/PostController.kt
@@ -15,6 +15,7 @@ import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.do
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response.PostResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response.PostSimplifiedResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.request.UpdatePostRequest
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response.PostReportResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.service.PostService
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.MemberPrincipal
 
@@ -122,4 +123,18 @@ class PostController(
         ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .body(postService.deleteReaction(channelId, boardId, postId, member.id))
+
+
+    @PostMapping("/{postId}/report")
+    fun reportPost(
+        @AuthenticationPrincipal member: MemberPrincipal,
+        @PathVariable channelId: Long,
+        @PathVariable boardId: Long,
+        @PathVariable postId: Long,
+        @RequestBody reason: String
+    ): ResponseEntity<PostReportResponse> =
+
+        ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(postService.reportPost(channelId, boardId, postId, reason, member.id))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/request/CreatePostRequest.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/request/CreatePostRequest.kt
@@ -7,5 +7,7 @@ data class CreatePostRequest (
     val title: String,
 
     @field:Size(min = 10, max = 8192, message = "최소 1자에서 최대 8192자까지 입력 가능합니다.")
-    val body: String
+    val body: String,
+
+    val tags: List<String>
 )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostReportResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostReportResponse.kt
@@ -1,0 +1,12 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response
+
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.ReportStatus
+import java.util.*
+
+data class PostReportResponse (
+    val id: Long,
+    val postInfo: PostSimplifiedResponse,
+    val reason: String,
+    val subject: UUID,
+    val status: ReportStatus
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostResponse.kt
@@ -8,8 +8,8 @@ data class PostResponse(
     val title: String,
     val body: String,
     val views: Long, // 조회수
-//    val upvoteCount: Int, // 추천
-//    val downvoteCount: Int, // 비추천
+    val upvotes: Long,
+    val downvotes: Long,
     val createdAt: ZonedDateTime,
     val updatedAt: ZonedDateTime,
     val author: String, // 닉네임

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostSimplifiedResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostSimplifiedResponse.kt
@@ -6,6 +6,8 @@ data class PostSimplifiedResponse(
     val id: Long,
     val title: String,
     val view: Long,
+    val upvotes: Long,
+    val downvotes: Long,
     val author: String,
     val createdAt: ZonedDateTime
 )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
@@ -1,9 +1,9 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model
 
 import jakarta.persistence.*
-import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.BaseTimeEntity
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.board.model.Board
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.board.model.toResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.ReactableEntity
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.request.CreatePostRequest
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response.PostResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response.PostSimplifiedResponse
@@ -17,7 +17,7 @@ class Post private constructor(
     board: Board,
     memberId: UUID,
     author: String
-) : BaseTimeEntity() {
+) : ReactableEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -78,6 +78,7 @@ class Post private constructor(
 
         this.views += 1
     }
+
 }
 
 fun Post.toResponse(): PostResponse =

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
@@ -88,6 +88,8 @@ fun Post.toResponse(): PostResponse =
         title = title,
         body = body,
         views = views,
+        upvotes = upvotes,
+        downvotes = downvotes,
         createdAt = createdAt,
         updatedAt = updatedAt,
         author = author,
@@ -101,6 +103,8 @@ fun Post.toPostSimplifiedResponse(): PostSimplifiedResponse =
         id = id!!,
         title = title,
         view = views,
+        upvotes = upvotes,
+        downvotes = downvotes,
         author = author,
         createdAt = createdAt
     )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostReaction.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostReaction.kt
@@ -1,0 +1,37 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+
+@Entity
+@Table(name = "post_reaction")
+class PostReaction private constructor (
+    member: Member,
+    post: Post,
+    isUpvoting: Boolean
+) {
+
+    @EmbeddedId
+    val id: PostReactionId = PostReactionId(
+        member = member,
+        post = post
+    )
+
+    @Column(name = "is_upvoting")
+    var isUpvoting: Boolean = isUpvoting
+
+
+    companion object {
+
+        fun from(member: Member, post: Post, isUpvoting: Boolean): PostReaction =
+
+            PostReaction(
+                member = member,
+                post = post,
+                isUpvoting = isUpvoting
+            )
+    }
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostReactionId.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostReactionId.kt
@@ -1,0 +1,18 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model
+
+import jakarta.persistence.Embeddable
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+
+@Embeddable
+class PostReactionId (
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    var post: Post? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    var member: Member? = null
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostReport.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostReport.kt
@@ -1,0 +1,48 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model
+
+import jakarta.persistence.*
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.BaseReport
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response.PostReportResponse
+
+@Entity
+@Table(name = "post_report")
+class PostReport private constructor (
+    post: Post,
+    reason: String,
+    subject: Member
+) : BaseReport(
+    reason = reason,
+    subject = subject
+) {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    val post: Post = post
+
+
+    companion object {
+
+        fun from(post: Post, reason: String, subject: Member): PostReport =
+
+            PostReport(
+                post = post,
+                reason = reason,
+                subject = subject
+            )
+    }
+}
+
+
+fun PostReport.toResponse(): PostReportResponse =
+
+    PostReportResponse(
+        id = id!!,
+        postInfo = post.toPostSimplifiedResponse(),
+        reason = reason,
+        subject = subject!!.id,
+        status = status
+    )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostTag.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostTag.kt
@@ -1,0 +1,31 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model
+
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "post_tag")
+class PostTag private constructor(
+    post: Post,
+    tag: Tag
+) {
+
+    @EmbeddedId
+    val id: PostTagId = PostTagId(
+        post = post,
+        tag = tag
+    )
+
+
+    companion object {
+
+        fun from(post: Post, tag: Tag): PostTag =
+
+            PostTag(
+                post = post,
+                tag = tag
+            )
+    }
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostTagId.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostTagId.kt
@@ -1,0 +1,17 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model
+
+import jakarta.persistence.Embeddable
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Embeddable
+class PostTagId(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    val post: Post,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_name", nullable = false)
+    val tag: Tag
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Tag.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Tag.kt
@@ -1,0 +1,29 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.common.type.BaseTimeEntity
+
+@Entity
+@Table(name = "tag")
+class Tag private constructor (
+    name: String
+) : BaseTimeEntity() {
+
+    @Id
+    val name: String = name
+
+
+    companion object {
+
+        fun from(name: String): Tag =
+
+            Tag(name = name)
+    }
+
+
+    fun refresh() {
+        preUpdate()
+    }
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostReactionRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostReactionRepository.kt
@@ -1,0 +1,11 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model.PostReaction
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model.PostReactionId
+import java.util.*
+
+interface PostReactionRepository : JpaRepository<PostReaction, PostReactionId> {
+
+    fun findByIdPostIdAndIdMemberId(postId: Long, memberId: UUID): PostReaction?
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostReportRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostReportRepository.kt
@@ -1,0 +1,6 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model.PostReport
+
+interface PostReportRepository : JpaRepository<PostReport, Long>

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostTagRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostTagRepository.kt
@@ -1,0 +1,7 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model.PostTag
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model.PostTagId
+
+interface PostTagRepository : JpaRepository<PostTag, PostTagId>

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/TagRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/TagRepository.kt
@@ -1,0 +1,6 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model.Tag
+
+interface TagRepository : JpaRepository<Tag, String>

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/querydsl/QueryDslSupport.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/querydsl/QueryDslSupport.kt
@@ -1,0 +1,14 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+
+abstract class QueryDslSupport {
+
+    @PersistenceContext
+    protected lateinit var entityManager: EntityManager
+
+    protected val queryFactory: JPAQueryFactory
+        get() = JPAQueryFactory(entityManager)
+}


### PR DESCRIPTION
# 개요

빠져 있던 도메인들의 (부분적) 구현

# 작업사항

- [x] `Comment`, `Post`, `GameReview`에 대하여 "반응"(`Reaction`) 추가
  - [x] `*Reaction` 이외에 그 수(좋아요 수 / 싫어요 수)를 각 `Entity`에 추가
  - [x] 각 `Response`에 좋아요/싫어요 수를 포함
- [x] 사용자 간 차단(`MemberBlacklist`) `Entity` 추가
- [x] 신고(`*Report`) `Entity` 추가
- [x] 쪽지(`Message`) `Entity` 추가
- [x] 게시글 태그(`Tag`) `Entity` 추가
- [x] `QueryDSL` 의존성 추가

# 관련 이슈

- close #33 

미완성된 기능 및 코드 리팩터링은 이후에 있을 새 이슈에서 다시 해 보겠습니다.
