### PR TITLE
Update/game review crud

### DIFF
--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/controller/GameReviewController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/controller/GameReviewController.kt
@@ -11,6 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.CreateGameReviewRequest
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.UpdateGameReviewRequest
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReactionResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReportResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.service.GameReviewService
@@ -124,4 +125,14 @@ class GameReviewController(
         ResponseEntity
             .status(HttpStatus.OK)
             .body(gameReviewService.getTopReviews())
+
+
+    @GetMapping("/reactions")
+    fun getGameReviewReactionList(
+        @AuthenticationPrincipal member: MemberPrincipal
+    ): ResponseEntity<List<GameReviewReactionResponse>> =
+
+        ResponseEntity
+            .status(HttpStatus.OK)
+            .body(gameReviewService.getGameReviewReactionList(member.id))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/controller/GameReviewController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/controller/GameReviewController.kt
@@ -11,7 +11,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.CreateGameReviewRequest
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.UpdateGameReviewRequest
-import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReactionResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReportResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.service.GameReviewService
@@ -125,14 +124,4 @@ class GameReviewController(
         ResponseEntity
             .status(HttpStatus.OK)
             .body(gameReviewService.getTopReviews())
-
-
-    @GetMapping("/reactions")
-    fun getGameReviewReactionList(
-        @AuthenticationPrincipal member: MemberPrincipal
-    ): ResponseEntity<List<GameReviewReactionResponse>> =
-
-        ResponseEntity
-            .status(HttpStatus.OK)
-            .body(gameReviewService.getGameReviewReactionList(member.id))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/dto/response/GameReviewReactionResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/dto/response/GameReviewReactionResponse.kt
@@ -1,0 +1,6 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response
+
+data class GameReviewReactionResponse(
+    val gameReviewId: Long,
+    val isUpvoting: Boolean
+)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/dto/response/GameReviewResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/dto/response/GameReviewResponse.kt
@@ -2,6 +2,7 @@ package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.d
 
 import java.io.Serializable
 import java.time.ZonedDateTime
+import java.util.UUID
 
 data class GameReviewResponse(
     val id: Long,
@@ -11,5 +12,6 @@ data class GameReviewResponse(
     val upvotes: Long,
     val downvotes: Long,
     val createdAt: ZonedDateTime,
-    val updatedAt: ZonedDateTime
+    val updatedAt: ZonedDateTime,
+    val memberId: UUID
 ): Serializable

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReview.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReview.kt
@@ -70,5 +70,6 @@ fun GameReview.toResponse(): GameReviewResponse =
         upvotes = upvotes,
         downvotes = downvotes,
         createdAt = createdAt,
-        updatedAt = updatedAt
+        updatedAt = updatedAt,
+        memberId = memberId
     )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReviewReaction.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReviewReaction.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReactionResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
 
 @Entity
@@ -35,3 +36,9 @@ class GameReviewReaction private constructor (
             )
     }
 }
+
+fun GameReviewReaction.toResponse(): GameReviewReactionResponse =
+
+    GameReviewReactionResponse(
+        gameReviewId = id.gameReview!!.id!!,
+        isUpvoting = isUpvoting)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/repository/GameReviewReactionRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/repository/GameReviewReactionRepository.kt
@@ -1,6 +1,7 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReviewReaction
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReviewReactionId
 import java.util.UUID
@@ -8,4 +9,8 @@ import java.util.UUID
 interface GameReviewReactionRepository : JpaRepository<GameReviewReaction, GameReviewReactionId> {
 
     fun findByIdGameReviewIdAndIdMemberId(gameReviewId: Long, memberId: UUID): GameReviewReaction?
+
+    fun findByIdMemberId(memberId: UUID): List<GameReviewReaction>
+
+    fun deleteByIdGameReviewId(gameReviewId: Long)
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/repository/GameReviewReactionRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/repository/GameReviewReactionRepository.kt
@@ -10,7 +10,8 @@ interface GameReviewReactionRepository : JpaRepository<GameReviewReaction, GameR
 
     fun findByIdGameReviewIdAndIdMemberId(gameReviewId: Long, memberId: UUID): GameReviewReaction?
 
-    fun findByIdMemberId(memberId: UUID): List<GameReviewReaction>
+    @Query("select grr from GameReviewReaction grr join fetch grr.id.gameReview where grr.id.member.id = :memberId")
+    fun findByMemberId(memberId: UUID): List<GameReviewReaction>
 
     fun deleteByIdGameReviewId(gameReviewId: Long)
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
@@ -178,5 +178,5 @@ class GameReviewService(
 
     fun getGameReviewReactionList(memberId: UUID): List<GameReviewReactionResponse> =
 
-        gameReviewReactionRepository.findByIdMemberId(memberId).map { it.toResponse() }
+        gameReviewReactionRepository.findByMemberId(memberId).map { it.toResponse() }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
@@ -185,9 +185,4 @@ class GameReviewService(
     fun getTopReviews(): List<GameReviewResponse> =
 
         gameReviewRepository.findTopGameReviews().map { it.toResponse() }
-
-
-    fun getGameReviewReactionList(memberId: UUID): List<GameReviewReactionResponse> =
-
-        gameReviewReactionRepository.findByMemberId(memberId).map { it.toResponse() }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
@@ -7,9 +7,10 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.CreateGameReviewRequest
-import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.request.UpdateGameReviewRequest
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReactionResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReportResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReview
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReviewReaction
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.GameReviewReport
@@ -21,7 +22,7 @@ import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.do
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.exception.CustomAccessDeniedException
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.exception.ModelNotFoundException
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.igdb.service.IgdbService
-import java.util.UUID
+import java.util.*
 
 @Service
 class GameReviewService(
@@ -38,7 +39,7 @@ class GameReviewService(
         memberId: UUID
     ): GameReviewResponse {
 
-        if(!igdbService.checkGamesName(request.gameTitle)) {
+        if (!igdbService.checkGamesName(request.gameTitle)) {
             throw CustomAccessDeniedException("다음과 같은 게임의 이름을 찾을 수 없습니다. ${request.gameTitle}")
         }
 
@@ -99,6 +100,8 @@ class GameReviewService(
         if (targetGameReview.memberId != memberId) {
             throw CustomAccessDeniedException("해당 게임리뷰에 대한 삭제 권한이 없습니다.")
         }
+
+        gameReviewReactionRepository.deleteByIdGameReviewId(gameReviewId)
 
         gameReviewRepository.delete(targetGameReview)
     }
@@ -171,4 +174,9 @@ class GameReviewService(
     fun getTopReviews(): List<GameReviewResponse> =
 
         gameReviewRepository.findTopGameReviews().map { it.toResponse() }
+
+
+    fun getGameReviewReactionList(memberId: UUID): List<GameReviewReactionResponse> =
+
+        gameReviewReactionRepository.findByMemberId(memberId).map { it.toResponse() }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
@@ -178,5 +178,5 @@ class GameReviewService(
 
     fun getGameReviewReactionList(memberId: UUID): List<GameReviewReactionResponse> =
 
-        gameReviewReactionRepository.findByMemberId(memberId).map { it.toResponse() }
+        gameReviewReactionRepository.findByIdMemberId(memberId).map { it.toResponse() }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/service/GameReviewService.kt
@@ -42,7 +42,7 @@ class GameReviewService(
     ): GameReviewResponse {
 
         if (!igdbService.checkGamesName(request.gameTitle)) {
-            throw CustomAccessDeniedException("다음과 같은 게임의 이름을 찾을 수 없습니다. ${request.gameTitle}")
+            throw IllegalArgumentException("다음과 같은 게임의 이름을 찾을 수 없습니다. ${request.gameTitle}")
         }
 
         return gameReviewRepository.save(

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/MemberController.kt
@@ -3,20 +3,14 @@ package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.d
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReactionResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberSimplifiedResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MessageResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.service.MemberService
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.MemberPrincipal
-import java.util.UUID
+import java.util.*
 
 @RestController
 @RequestMapping("/api/v1")
@@ -38,7 +32,6 @@ class MemberController(
         ResponseEntity
             .status(HttpStatus.OK)
             .body(memberService.getSimpleMember(UUID.fromString(id)))
-
 
 
     /*
@@ -81,4 +74,14 @@ class MemberController(
         ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .body(memberService.removeBlacklist(principal.id, targetId))
+
+
+    @GetMapping("/reactions")
+    fun getGameReviewReactionList(
+        @AuthenticationPrincipal member: MemberPrincipal
+    ): ResponseEntity<List<GameReviewReactionResponse>> =
+
+        ResponseEntity
+            .status(HttpStatus.OK)
+            .body(memberService.getGameReviewReactionList(member.id))
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/MemberController.kt
@@ -76,7 +76,7 @@ class MemberController(
             .body(memberService.removeBlacklist(principal.id, targetId))
 
 
-    @GetMapping("/reactions")
+    @GetMapping("/member/reactions")
     fun getGameReviewReactionList(
         @AuthenticationPrincipal member: MemberPrincipal
     ): ResponseEntity<List<GameReviewReactionResponse>> =

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/service/MemberService.kt
@@ -3,6 +3,9 @@ package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.d
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.dto.response.GameReviewReactionResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.model.toResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.gamereview.repository.GameReviewReactionRepository
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MemberSimplifiedResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.MessageResponse
@@ -14,13 +17,14 @@ import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.do
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MemberRepository
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MessageRepository
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.exception.ModelNotFoundException
-import java.util.UUID
+import java.util.*
 
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
     private val memberBlacklistRepository: MemberBlacklistRepository,
-    private val messageRepository: MessageRepository
+    private val messageRepository: MessageRepository,
+    private val gameReviewReactionRepository: GameReviewReactionRepository
 ) {
 
     fun getMember(id: UUID): MemberResponse =
@@ -49,7 +53,7 @@ class MemberService(
             ?: throw ModelNotFoundException("Member", targetId)
 
         return messageRepository.save(
-            Message.from (
+            Message.from(
                 subject = member,
                 target = target,
                 message = message
@@ -90,4 +94,9 @@ class MemberService(
 
         memberBlacklistRepository.delete(targetMemberBlacklist)
     }
+
+
+    fun getGameReviewReactionList(memberId: UUID): List<GameReviewReactionResponse> =
+
+        gameReviewReactionRepository.findByMemberId(memberId).map { it.toResponse() }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/config/SecurityConfig.kt
@@ -11,6 +11,9 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.OAuth2Service
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.jwt.jwtAuthenticationFilter
 
@@ -31,6 +34,7 @@ class SecurityConfig(
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
             .csrf { it.disable() }
+            .cors { it.configurationSource(corsConfigurationSource()) } // cors 설정
             .authorizeHttpRequests {
                 it.requestMatchers(HttpMethod.GET, "/**")
                     .permitAll()
@@ -62,4 +66,20 @@ class SecurityConfig(
             }
             .build()
 
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+
+        configuration.setAllowedOriginPatterns(listOf("*"))
+        configuration.allowedMethods = listOf("HEAD", "GET", "POST", "PUT", "DELETE", "OPTIONS")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
+        configuration.addExposedHeader("Set-Cookie")
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+
+        return source
+    }
 }


### PR DESCRIPTION
# 개요

Client와 연결하면서 GameReview CRUD에서 추가/수정해야할 부분 반영

# 작업사항

- [x] 클라이언트에서 게임리뷰 수정/삭제 버튼 활성화를 위한 리뷰 작성자의 ID를 응답에 포함
- [x] 게임리뷰 삭제 시 연관된 추천/비추천 삭제
- [x] 로그인한 사용자의 추천/비추천 여부를 응답하는 API 추가 - 리뷰 목록에 보여주기 위함
- [x] 사용자의 추천/비추천 조회 시 발생하는 N+1 문제 해결
- [x] GameReview쪽에 포함된 사용자의 추천/비추천 조회 API를 Member쪽으로 이동
- [x] CORS Error 해결을 위한 Security 설정 추가 
- [x] 게임 이름을 찾을 수 없는 경우에 대한 예외 처리 수정

# 관련 이슈

- close #49 
