### PR TITLE
Fix: 조회 수 증가 시 게시물의 수정일자가 변경되는 문제 수정

### DIFF
--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/board/model/Board.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/board/model/Board.kt
@@ -51,6 +51,7 @@ class Board private constructor(
 
         title = updateBoardRequest.title
         introduction = updateBoardRequest.introduction
+        preUpdate()
     }
 }
 

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/channel/model/Channel.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/channel/model/Channel.kt
@@ -64,6 +64,7 @@ class Channel private constructor(
 
         title = updateChannelRequest.title
         introduction = updateChannelRequest.introduction
+        preUpdate()
     }
 }
 

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/Comment.kt
@@ -54,6 +54,7 @@ class Comment private constructor(
     fun update(content: String) {
 
         this.content = content
+        preUpdate()
     }
 }
 

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/common/type/BaseTimeEntity.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/common/type/BaseTimeEntity.kt
@@ -17,7 +17,6 @@ abstract class BaseTimeEntity {
         private set
 
 
-    @PreUpdate
     fun preUpdate() {
 
         updatedAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReview.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/gamereview/model/GameReview.kt
@@ -57,6 +57,7 @@ class GameReview private constructor(
 
         this.description = description
         this.point = point
+        preUpdate()
     }
 }
 

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/Member.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/model/Member.kt
@@ -63,6 +63,7 @@ class Member private constructor(
     fun assignChannelAdmin() {
 
         role = MemberRole.CHANNEL_ADMIN
+        preUpdate()
     }
 }
 

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
@@ -79,6 +79,7 @@ class Post private constructor(
         this.title = title
         this.body = body
         this.attachment = attachment
+        preUpdate()
     }
 
 


### PR DESCRIPTION
# 개요

조회 수 증가 시 게시물의 수정일자가 변경되는 문제 수정

# 작업사항

- [x] 조회 수 증가 시 게시물의 수정일자가 변경되는 문제 수정


# 관련 이슈

- close #54 
