### PR TITLE
Fix: Google 소셜 로그인 프론트 연결

### DIFF
--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/AuthController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/member/controller/AuthController.kt
@@ -40,4 +40,3 @@ class AuthController(
             .status(HttpStatus.OK)
             .body(authService.googleSignin(principal.email()))
 }
-

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/oauth2/OAuth2Service.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/oauth2/OAuth2Service.kt
@@ -1,17 +1,22 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra
 
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.OAuth2Response
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.SigninResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.model.Member
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.repository.MemberRepository
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.jwt.JwtHelper
 
 
 @Service
 class OAuth2Service(
     private val memberRepository: MemberRepository,
+    private val jwtHelper: JwtHelper
 ) : DefaultOAuth2UserService() {
 
     override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
@@ -35,5 +40,23 @@ class OAuth2Service(
         }
 
         return CustomOAuth2User(oAuth2Response, role)
+    }
+
+
+    fun googleSignin(authentication: Authentication): String {
+
+        val oauthToken = authentication as OAuth2AuthenticationToken
+        val internalToken = oauthToken.principal as CustomOAuth2User
+        val member = memberRepository.findByEmail(internalToken.email())
+            ?: throw IllegalArgumentException("회원정보를 찾을 수 없습니다.")
+        val token = SigninResponse(
+            accessToken = jwtHelper.generateAccessToken(
+                subject = member.id.toString(),
+                email = member.email,
+                role = member.role.name
+            )
+        )
+        return "http://127.0.0.1:5173/login/google?token=${token.accessToken}"
+
     }
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/security/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.config
 
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -8,12 +9,17 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.member.dto.response.OAuth2Response
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.CustomOAuth2User
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.OAuth2Service
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.jwt.jwtAuthenticationFilter
 
@@ -24,7 +30,7 @@ import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.in
 class SecurityConfig(
     private val jwtAuthenticationFilter: jwtAuthenticationFilter,
     private val authenticationEntryPoint: AuthenticationEntryPoint,
-    private val customOAuth2UserService: OAuth2Service,
+    private val customOAuth2UserService: OAuth2Service
 ) {
 
     @Bean
@@ -53,7 +59,10 @@ class SecurityConfig(
             .oauth2Login {
                 it.loginProcessingUrl("/google")
                 it.userInfoEndpoint { u -> u.userService(customOAuth2UserService) }
-                it.defaultSuccessUrl("/api/v1/auth/signin/google")
+                it.successHandler { request, response, authentication ->
+                    response.sendRedirect(customOAuth2UserService.googleSignin(authentication))
+//                    response.writer.write(customOAuth2UserService.googleSignin(authentication))
+                }
                 it.failureHandler { request, response, exception ->
                     response.status = HttpServletResponse.SC_UNAUTHORIZED
                     response.contentType = "application/json"


### PR DESCRIPTION
# 개요

성공 시 api를 실행시키지 않고 핸들러를 이용하여 서비스 실행

# 작업사항

- [x] 구글 로그인 로직 변경

# 관련 이슈

- close #34 
