### PR TITLE
Feature/#68 update post domain

### DIFF
--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/controller/PostController.kt
@@ -16,6 +16,7 @@ import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.do
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response.PostSimplifiedResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.request.UpdatePostRequest
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response.PostReportResponse
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response.PostTagResponse
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.service.PostService
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.MemberPrincipal
 
@@ -65,6 +66,18 @@ class PostController(
         ResponseEntity
             .status(HttpStatus.OK)
             .body(postService.getPost(channelId, boardId, postId, request, response))
+
+
+    @GetMapping("/{postId}/tags")
+    fun getTagsInPost(
+        @PathVariable channelId: Long,
+        @PathVariable boardId: Long,
+        @PathVariable postId: Long,
+    ): ResponseEntity<List<PostTagResponse>> =
+
+        ResponseEntity
+            .status(HttpStatus.OK)
+            .body(postService.getTagsInPost(channelId, boardId, postId))
 
 
     @PutMapping("/{postId}")

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/request/UpdatePostRequest.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/request/UpdatePostRequest.kt
@@ -9,5 +9,7 @@ data class UpdatePostRequest (
     @field:Size(min = 10, max = 8192, message = "최소 1자에서 최대 8192자까지 입력 가능합니다.")
     val body: String,
 
+    val tags: List<String>,
+
     val attachment: String?,
 )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostTagResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostTagResponse.kt
@@ -1,0 +1,7 @@
+package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response
+
+import java.io.Serializable
+
+data class PostTagResponse(
+    val name: String
+): Serializable

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
@@ -28,7 +28,7 @@ class Post private constructor(
     var title: String = title
         private set
 
-    @Column(name = "body", nullable = false)
+    @Column(name = "body", columnDefinition = "MEDIUMTEXT", nullable = false)
     var body: String = body
         private set
 

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostTag.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/PostTag.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response.PostTagResponse
 
 @Entity
 @Table(name = "post_tag")
@@ -29,3 +30,9 @@ class PostTag private constructor(
             )
     }
 }
+
+fun PostTag.toResponse(): PostTagResponse =
+
+    PostTagResponse(
+        name = id.tag.name
+    )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostTagRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostTagRepository.kt
@@ -1,7 +1,12 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model.PostTag
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.model.PostTagId
 
-interface PostTagRepository : JpaRepository<PostTag, PostTagId>
+interface PostTagRepository : JpaRepository<PostTag, PostTagId> {
+
+    @Query("select pt from PostTag pt join fetch pt.id.post where pt.id.post.id = :postId")
+    fun findAllTagsByPostId(postId: Long): List<PostTag>
+}

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/s3/fileupload/controller/FileUploadController.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/s3/fileupload/controller/FileUploadController.kt
@@ -10,7 +10,7 @@ import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.in
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.infra.security.MemberPrincipal
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/s3")
 class FileUploadController(
     private val fileUploadService: FileUploadService,
 ) {
@@ -40,15 +40,14 @@ class FileUploadController(
 
 
     // 이미지 전체 조회
-    @GetMapping("/{bucket}/**")
+    @GetMapping("/list/**")
     fun find(
-        @PathVariable bucket: String,
         request: HttpServletRequest
     ): ResponseEntity<S3GetResponseDto> =
 
         ResponseEntity
             .status(HttpStatus.OK)
-            .body(fileUploadService.find(bucket, request))
+            .body(fileUploadService.find(request))
 
 
     // 이미지 삭제

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/s3/fileupload/service/FileUploadService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/infra/s3/fileupload/service/FileUploadService.kt
@@ -46,11 +46,10 @@ class FileUploadService(
 
 
     fun find(
-        bucket: String,
         request: HttpServletRequest
     ): S3GetResponseDto {
 
-        val split = request.requestURI.split("/s3/$bucket")
+        val split = request.requestURI.split("/s3/list")
         val prefix = if (split.size < 2) "" else split[1].substring(1)
 
         val fileNames = mutableListOf<String>()


### PR DESCRIPTION
# 개요

- 태그와 관련하여 조회/수정/삭제하는 기능 보강
- 파일 업로드 시 발생하는 API 경로 충돌 해결

# 작업사항

- [x] 본문에 길이 제한(255글자)이 걸렸던 오류 수정
- [x] 태그 관련 `DTO` 추가
  - [x] 게시글 수정/삭제 시 태그 갱신 및 삭제하는 기능 구현
  - [x] 게시글에 달린 태그 조회하는 API Call 추가
- [x] 파일 업로드 시 발생하는 문제 해결
  - [x] 파일 업로드 관련 API에 중간경로 `s3` 추가
  - [x] 이미지 목록 조회하는 API 경로에서 `bucket` 삭제
  - [x] 이미지 목록 조회 시 경로 단계 추가(를 통해 다른 API 경로와 충돌하는 문제 해결)

# 관련 이슈

- close #68
