### PR TITLE
Fix `Post` `assignment`-related domain

### DIFF
--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
@@ -37,7 +37,7 @@ class Post private constructor(
         private set
 
     @Column(name = "attachment", nullable = true)
-    var attachment: String? = null
+    var attachment: String? = attachment
         private set
 
     @Column(name = "member_id", nullable = false)

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/service/PostService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/service/PostService.kt
@@ -76,7 +76,7 @@ class PostService(
                 )
             }
 
-            postRepository.save(newPost).toResponse()
+            newPost.toResponse()
         }
 
 


### PR DESCRIPTION
# 개요

`Post` 도메인에서 `Post` `entity`가 `attachment` 속성을 받지 않는 오류 수정

# 작업사항

- [x] post 생성 시 첨부물 접두어를 받지 않는 오류 수정

# 관련 이슈

- close #77 
