### PR TITLE
Feature/#82 update item responses

### DIFF
--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/dto/response/CommentResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/dto/response/CommentResponse.kt
@@ -1,11 +1,13 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.comment.dto.response
 
 import java.time.ZonedDateTime
+import java.util.UUID
 
 data class CommentResponse(
     val id: Long,
     val content: String,
     val author: String,
+    val memberId: UUID,
     val upvotes: Long,
     val downvotes: Long,
     val createdAt: ZonedDateTime,

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/model/Comment.kt
@@ -64,6 +64,7 @@ fun Comment.toResponse(): CommentResponse =
         id = id!!,
         content = content,
         author = author,
+        memberId = memberId,
         upvotes = upvotes,
         downvotes = downvotes,
         createdAt = createdAt,

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/repository/CommentReactionRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/repository/CommentReactionRepository.kt
@@ -12,4 +12,10 @@ interface CommentReactionRepository : JpaRepository<CommentReaction, CommentReac
 
     @Query("select cr from CommentReaction cr join fetch cr.id.comment where cr.id.member.id = :memberId")
     fun findByMemberId(memberId: UUID): List<CommentReaction>
+
+    @Query("select cr from CommentReaction cr join fetch cr.id.comment where cr.id.comment.id = :commentId")
+    fun findAllByCommentId(commentId: Long): List<CommentReaction>
+
+    @Query("select cr from CommentReaction cr join fetch cr.id.comment where cr.id.comment.id in :commentIds")
+    fun findAllByCommentIdIn(commentIds: List<Long>): List<CommentReaction>
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/comment/service/CommentService.kt
@@ -108,6 +108,8 @@ class CommentService(
         doAfterResourceValidation(channelId, boardId, postId, commentId, memberId) { _, targetComment, member ->
             checkCommentOwnership(targetComment!!, member!!)
 
+            val commentReactions = commentReactionRepository.findAllByCommentId(targetComment.id!!)
+            commentReactionRepository.deleteAllInBatch(commentReactions)
             commentRepository.delete(targetComment)
         }
     }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostResponse.kt
@@ -3,6 +3,7 @@ package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.d
 import spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.board.dto.response.BoardResponse
 import java.io.Serializable
 import java.time.ZonedDateTime
+import java.util.UUID
 
 data class PostResponse(
     val id: Long,
@@ -14,6 +15,7 @@ data class PostResponse(
     val createdAt: ZonedDateTime,
     val updatedAt: ZonedDateTime,
     val author: String, // 닉네임
+    val memberId: UUID,
     val board: BoardResponse,
     val attachment: String?,
 ): Serializable

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostSimplifiedResponse.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/dto/response/PostSimplifiedResponse.kt
@@ -1,6 +1,7 @@
 package spartacodingclub.nbcamp.kotlinspring.project.team4ighting.spring4gamer.domain.post.dto.response
 
 import java.time.ZonedDateTime
+import java.util.UUID
 
 data class PostSimplifiedResponse(
     val id: Long,
@@ -9,6 +10,7 @@ data class PostSimplifiedResponse(
     val upvotes: Long,
     val downvotes: Long,
     val author: String,
+    val memberId: UUID,
     val createdAt: ZonedDateTime,
     val attachment: String?,
 )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/model/Post.kt
@@ -102,6 +102,7 @@ fun Post.toResponse(): PostResponse =
         createdAt = createdAt,
         updatedAt = updatedAt,
         author = author,
+        memberId = memberId,
         board = board.toResponse(),
         attachment = attachment,
     )
@@ -116,6 +117,7 @@ fun Post.toPostSimplifiedResponse(): PostSimplifiedResponse =
         upvotes = upvotes,
         downvotes = downvotes,
         author = author,
+        memberId = memberId,
         createdAt = createdAt,
         attachment = attachment,
     )

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostReactionRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostReactionRepository.kt
@@ -12,4 +12,10 @@ interface PostReactionRepository : JpaRepository<PostReaction, PostReactionId> {
 
     @Query("select pr from PostReaction pr join fetch pr.id.post where pr.id.member.id = :memberId")
     fun findByMemberId(memberId: UUID): List<PostReaction>
+
+    @Query("select pr from PostReaction pr join fetch pr.id.post where pr.id.post.id = :postId")
+    fun findByPostId(postId: Long): List<PostReaction>
+
+    @Query("select pr from PostReaction pr join fetch pr.id.post where pr.id.post.id in :postIds")
+    fun findAllByPostIdIn(postIds: List<Long>): List<PostReaction>
 }

--- a/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostTagRepository.kt
+++ b/src/main/kotlin/spartacodingclub/nbcamp/kotlinspring/project/team4ighting/spring4gamer/domain/post/repository/PostTagRepository.kt
@@ -9,4 +9,7 @@ interface PostTagRepository : JpaRepository<PostTag, PostTagId> {
 
     @Query("select pt from PostTag pt join fetch pt.id.post where pt.id.post.id = :postId")
     fun findAllTagsByPostId(postId: Long): List<PostTag>
+
+    @Query("select pt from PostTag pt join fetch pt.id.post where pt.id.post.id in :postIds")
+    fun findAllByPostIdIn(postIds: List<Long>): List<PostTag>
 }


### PR DESCRIPTION
# 개요
프론트엔드와 연동하면서 (게시글과 댓글 관련하여) 필요했던 항목들 추가

# 작업사항
- [x] 댓글과 게시글 관련 응답 `DTO`에 작성자의 `UUID` 추가
- [x] 댓글과 게시글을 삭제할 때 관련 반응이나 태그까지 삭제하게 코드 수정(삭제하지 않아서 constraint를 어겨버리게 되어 본래 삭제를 진행하지 못하는 상황이 생겼었음)

# 관련 이슈
- close #82 
